### PR TITLE
Temporary fix to the connection loss

### DIFF
--- a/pypga/core/interface/remote/client.py
+++ b/pypga/core/interface/remote/client.py
@@ -8,7 +8,7 @@ import numpy as np
 
 
 class Client:
-    def __init__(self, token, host="127.0.0.1", port=2222, timeout=1.0):
+    def __init__(self, token, host="127.0.0.1", port=2222, timeout=10.0):
         if len(token) != 32:
             raise ValueError("token must have 32 characters, not {len(token)}.")
         self._token = token
@@ -153,7 +153,7 @@ class Client:
             try:
                 self._clear_socket()
             finally:
-                raise RuntimeError(f"Error: wrong control sequence from server: {ack}")
+                raise RuntimeError(f"Error: wrong control sequence from server, expceted: {header}, got: {ack}")
 
     def _clear_socket(self):
         total_bytes_cleared = 0


### PR DESCRIPTION
This is a very hacky solution to the connection loss that we've been having. It is indeed a network card issue, and not a server issue.  After running Wireshark on the Ethernet interface, the time of the packet before it times out exceeds 1s. This is caused by multiple packets being sent at the same time and them getting resolved one by one. A proper solution would be moving away from socket.SOCKET, and to something that has proper packet queuing. 

Will attach some screenshots from Wireshark on Monday