### PR TITLE
Remove saturation errors from console

### DIFF
--- a/pypga/__init__.py
+++ b/pypga/__init__.py
@@ -3,3 +3,14 @@ PYthon Programmable Gate Array
 """
 from . import boards, core, modules
 from .core import interface
+
+import logging
+from logging.handlers import RotatingFileHandler
+
+# Basic configuration for logging
+logging.basicConfig(
+    handlers=[RotatingFileHandler('./pypga_warning.log', maxBytes=100000, backupCount=5)],
+    level=logging.WARNING,  # Set the logging level to WARNING
+    format='%(asctime)s - %(name)s - %(levelname)s - %(filename)s:%(lineno)d - %(funcName)s() - %(message)s'  # Custom format
+)
+print([k for k in logging.Logger.manager.loggerDict])

--- a/pypga/__init__.py
+++ b/pypga/__init__.py
@@ -7,10 +7,8 @@ from .core import interface
 import logging
 from logging.handlers import RotatingFileHandler
 
-# Basic configuration for logging
 logging.basicConfig(
     handlers=[RotatingFileHandler('./pypga_warning.log', maxBytes=100000, backupCount=5)],
-    level=logging.WARNING,  # Set the logging level to WARNING
-    format='%(asctime)s - %(name)s - %(levelname)s - %(filename)s:%(lineno)d - %(funcName)s() - %(message)s'  # Custom format
+    level=logging.WARNING,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(filename)s:%(lineno)d - %(funcName)s() - %(message)s'
 )
-print([k for k in logging.Logger.manager.loggerDict])


### PR DESCRIPTION
This PR removes the saturation errors from being displayed in the console, and moves them to a log file called "pypga_warning.log".